### PR TITLE
Disable print to pdf timeout

### DIFF
--- a/src/Browser.js
+++ b/src/Browser.js
@@ -39,7 +39,8 @@ exports.pdf = async (page, params, rawData) => {
     scale: 1,
     printBackground: !!printBackground,
     landscape: !!landscape,
-    margin: margin
+    margin: margin,
+    timeout: 0
   });
 
   return rawData ? pdfData : pdfData.toString("base64");


### PR DESCRIPTION
Disable the new `timeout` setting.
This is necessary after the recent puppeteer update