### PR TITLE
Improved handling of `renderEventName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Creates a PDF of the given page by simulating a printout.
 - `format`: Format of the page. This parameter will be forwarded to Puppeteer, so you can find a detailed explanation [here](https://github.com/puppeteer/puppeteer/blob/v5.2.1/docs/api.md#pagepdfoptions).
 - `cookies`: Cookies which will be set before taking the screenshot. You can find a detailed explanation below.
 - `renderEventName`: The RenderFunctionName. You can find a detailed explanation below.
-- `renderEventNameTimeout`: The Timeout in milliseconds for waiting to call `renderEventName`. If not specified, the default Timeout of the Fury Application will be used. Must be smaller than the global Request Timeout
+- `renderEventNameTimeout`: The timeout in milliseconds for waiting to call `renderEventName`. If not specified, the default Timeout of the Fury Application will be used. Must be smaller than the global Request Timeout
 - `printBackground`: Include background media in the pdf ? This parameter will be forwarded to Puppeteer, so you can find a detailed explanation [here](https://github.com/puppeteer/puppeteer/blob/v5.2.1/docs/api.md#pagepdfoptions).
 - `landscape`: Is the page landscape orientated ? Only works, if `format` is provided. This parameter will be forwarded to Puppeteer, so you can find a detailed explanation [here](https://github.com/puppeteer/puppeteer/blob/v5.2.1/docs/api.md#pagepdfoptions).
 - `margin`: Margin for the printout. This parameter will be forwarded to Puppeteer, so you can find a detailed explanation [here](https://github.com/puppeteer/puppeteer/blob/v5.2.1/docs/api.md#pagepdfoptions).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Creates a PDF of the given page by simulating a printout.
 - `format`: Format of the page. This parameter will be forwarded to Puppeteer, so you can find a detailed explanation [here](https://github.com/puppeteer/puppeteer/blob/v5.2.1/docs/api.md#pagepdfoptions).
 - `cookies`: Cookies which will be set before taking the screenshot. You can find a detailed explanation below.
 - `renderEventName`: The RenderFunctionName. You can find a detailed explanation below.
+- `renderEventNameTimeout`: The Timeout in milliseconds for waiting to call `renderEventName`. If not specified, the default Timeout of the Fury Application will be used. Must be smaller than the global Request Timeout
 - `printBackground`: Include background media in the pdf ? This parameter will be forwarded to Puppeteer, so you can find a detailed explanation [here](https://github.com/puppeteer/puppeteer/blob/v5.2.1/docs/api.md#pagepdfoptions).
 - `landscape`: Is the page landscape orientated ? Only works, if `format` is provided. This parameter will be forwarded to Puppeteer, so you can find a detailed explanation [here](https://github.com/puppeteer/puppeteer/blob/v5.2.1/docs/api.md#pagepdfoptions).
 - `margin`: Margin for the printout. This parameter will be forwarded to Puppeteer, so you can find a detailed explanation [here](https://github.com/puppeteer/puppeteer/blob/v5.2.1/docs/api.md#pagepdfoptions).

--- a/src/BrowserUtils.js
+++ b/src/BrowserUtils.js
@@ -113,16 +113,15 @@ exports.navigate = async (useDimensionsFromParams, page, params) => {
 
   await setCookies(page, cookies, url);
 
-  let renderEventTimeoutDefined = false;
-  let renderEventTimeout = timeout || Utils.DEFAULT_TIMEOUT;
+  const defaultTimeout = timeout || Utils.DEFAULT_TIMEOUT;
+  let renderEventTimeout = defaultTimeout;
 
   if (renderEventNameTimeout && renderEventNameTimeout < renderEventTimeout) {
     renderEventTimeout = renderEventNameTimeout;
-    renderEventTimeoutDefined = true;
   }
 
   const
-    renderEventPromise = exports.getRenderEventPromise(page, renderEventName, renderEventTimeout, renderEventTimeoutDefined);
+    renderEventPromise = exports.getRenderEventPromise(page, renderEventName, renderEventTimeout, renderEventTimeout < defaultTimeout);
 
   await page.goto(url, {
     waitUntil: "networkidle0"


### PR DESCRIPTION
- Log an error if `renderEventName` won't be called instead of crashing the whole application because `renderEventPromise` had thrown an error which we didn't catched. Now, the preomise won't throw any error instead it just logs it
- Add a new option `renderEventNameTimeout` to specifiy a special timeout for `renderEventName` to keep processing the page even if `renderEventName` won't be called within a time frame. This ensures, that fury will always return a result even if `renderEventName` won't be called
- Forward the log from the page