### PR TITLE
New Export Type JSON

### DIFF
--- a/server.js
+++ b/server.js
@@ -127,3 +127,4 @@ const createHandler = (functionName, extension) => {
 app.post("/screenshot", createHandler("screenshot", "jpeg"));
 app.post("/pdf", createHandler("pdf", "pdf"));
 app.post("/file", createHandler("file", "bin"));
+app.post("/json", createHandler("json", "json"));


### PR DESCRIPTION
This Export is meant as a very performant alternative to the file export, hence why it only works with FURY_SAVE_DIR set.
Instead of stringifing a json object in the frontend, sending it as a blob, converting it to base64 before saving it to a file, we send the json object directly to puppeteer, which stringifies and saves it. The Export also does not return any data, since this isn't needed... The Data is already saved in a file, we can skip returning the data.
The Export is specifically built for performing extremely large json exports in for instance eVolution