### PR TITLE
Fix ENOENT error when writing to files in File Export

### DIFF
--- a/src/Browser.js
+++ b/src/Browser.js
@@ -102,10 +102,16 @@ exports.file = async (page, params, rawData, fileOptions = {}) => {
 
   if (fileOptions.path) {
     const buffer = await decoded.arrayBuffer();
-    const fd = fs.openSync(fileOptions.path, 'w');
-    fs.writeSync(fd, Buffer.from(buffer));
-    fs.fsyncSync(fd);
-    fs.closeSync(fd);
+    let fileHandle;
+    try {
+      fileHandle = await fs.promises.open(fileOptions.path, 'w');
+      await fileHandle.write(Buffer.from(buffer));
+      await fileHandle.sync();
+    } finally {
+      if (fileHandle) {
+        await fileHandle.close();
+      }
+    }
   }
 
   const bytes = await decoded.bytes();

--- a/src/Browser.js
+++ b/src/Browser.js
@@ -102,7 +102,10 @@ exports.file = async (page, params, rawData, fileOptions = {}) => {
 
   if (fileOptions.path) {
     const buffer = await decoded.arrayBuffer();
-    fs.createWriteStream(fileOptions.path).write(Buffer.from(buffer));
+    const fd = fs.openSync(fileOptions.path, 'w');
+    fs.writeSync(fd, Buffer.from(buffer));
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
   }
 
   const bytes = await decoded.bytes();


### PR DESCRIPTION
The old logic wrote the file but never actually waited for the process to be finished.. This caused a race condition, where the "finished" Answer to the server was sent before the file was done being written... This fixes that issue