### PR TITLE
Screenshot `quality` parameter + set default from 100 to 90

### DIFF
--- a/src/Browser.js
+++ b/src/Browser.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 
 exports.screenshot = async (page, params, rawData, screenshotOptions = {}) => {
   const
-    {url} = params;
+    {url, quality} = params;
 
   // We need to have an url parameter to proceed
   if (!url) {
@@ -14,7 +14,7 @@ exports.screenshot = async (page, params, rawData, screenshotOptions = {}) => {
   await BrowserUtils.navigate(true, page, params);
 
   const imageData = await page.screenshot({
-    quality: 100,
+    quality: quality ?? 90,
     encoding: rawData ? "binary" : "base64",
     type: "jpeg",
     ...screenshotOptions


### PR DESCRIPTION
90% quality should be adequate for most use cases and gives us more optimal file sizes.