### PR TITLE
Calculate scale factor for pdf export dynamically

### DIFF
--- a/src/Browser.js
+++ b/src/Browser.js
@@ -66,7 +66,7 @@ exports.pdf = async (page, params, rawData, pdfOptions = {}) => {
   }
 
   let scale = 1;
-  if (unit === "px") {
+  if (unit === "px" && pageWidth) {
     // Fury renders at 96DPI
     let widthInt = -1;
     try {


### PR DESCRIPTION
If `px` as browser page size unit is used, calculate the scale factor dynamically.
Fury renders always with 96dpi, so we can calculate the pixel width with scale `1` and with that result we can calculate the actual scale factor when rendering pages with higher/lower resolution.

This affects the result pdf quality especially when rendering images on the pdf since the browser page size is higher so the image sizes in px are also larger depending on the content